### PR TITLE
[ZERO-6329] Verification code does not exist in the verification email

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,0 +1,6 @@
+import Config
+
+config :gettext, :default_locale, "en"
+
+# Application.fetch_env!(:gettext, :default_locale)
+# Application.get_env(:gettext, :default_locale)

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,6 +1,0 @@
-import Config
-
-config :gettext, :default_locale, "en"
-
-# Application.fetch_env!(:gettext, :default_locale)
-# Application.get_env(:gettext, :default_locale)

--- a/lib/gettext.ex
+++ b/lib/gettext.ex
@@ -701,7 +701,7 @@ defmodule Gettext do
     allowed_locales = known_locales(backend)
     is_not_allowed_local = locale not in allowed_locales
 
-    if is_not_allowed_local, do: put_locale(backend, "en")
+    if is_not_allowed_local, do: Process.put(backend, "en")
   end
 
   @doc """
@@ -771,11 +771,7 @@ defmodule Gettext do
   """
   @doc section: :locale
   @spec put_locale(backend, locale) :: locale | nil
-  def put_locale(backend, locale) when is_binary(locale) do
-    language_fallback(backend)
-
-    Process.put(backend, locale)
-  end
+  def put_locale(backend, locale) when is_binary(locale), do: language_fallback(backend)
 
   def put_locale(_backend, locale),
     do: raise(ArgumentError, "put_locale/2 only accepts binary locales, got: #{inspect(locale)}")

--- a/lib/gettext.ex
+++ b/lib/gettext.ex
@@ -697,11 +697,12 @@ defmodule Gettext do
 
   @spec language_fallback(backend) :: binary() | nil
   defp language_fallback(backend) do
+    fallback_language = Application.get_env(:gettext, :default_locale, "en")
     locale = get_locale(backend)
     allowed_locales = known_locales(backend)
     is_not_allowed_local = locale not in allowed_locales
 
-    if is_not_allowed_local, do: Process.put(backend, "en")
+    if is_not_allowed_local, do: Process.put(backend, fallback_language)
   end
 
   @doc """

--- a/lib/gettext.ex
+++ b/lib/gettext.ex
@@ -695,14 +695,16 @@ defmodule Gettext do
 
   # fallback language to "en" if the language is not allowed in the backend allowed_locales option
 
-  @spec language_fallback(backend) :: binary() | nil
-  defp language_fallback(backend) do
-    fallback_language = Application.get_env(:gettext, :default_locale, "en")
-    locale = get_locale(backend)
+  @spec language_fallback(backend, locale) :: binary() | nil
+  defp language_fallback(backend, locale) do
     allowed_locales = known_locales(backend)
     is_not_allowed_local = locale not in allowed_locales
 
-    if is_not_allowed_local, do: Process.put(backend, fallback_language)
+    if is_not_allowed_local do
+      Process.put(backend, "en")
+    else
+      Process.put(backend, locale)
+    end
   end
 
   @doc """
@@ -772,7 +774,7 @@ defmodule Gettext do
   """
   @doc section: :locale
   @spec put_locale(backend, locale) :: locale | nil
-  def put_locale(backend, locale) when is_binary(locale), do: language_fallback(backend)
+  def put_locale(backend, locale) when is_binary(locale), do: language_fallback(backend, locale)
 
   def put_locale(_backend, locale),
     do: raise(ArgumentError, "put_locale/2 only accepts binary locales, got: #{inspect(locale)}")

--- a/lib/gettext.ex
+++ b/lib/gettext.ex
@@ -693,6 +693,17 @@ defmodule Gettext do
     end
   end
 
+  # fallback language to "en" if the language is not allowed in the backend allowed_locales option
+
+  @spec language_fallback(backend) :: binary() | nil
+  defp language_fallback(backend) do
+    locale = get_locale(backend)
+    allowed_locales = known_locales(backend)
+    is_not_allowed_local = locale not in allowed_locales
+
+    if is_not_allowed_local, do: put_locale(backend, "en")
+  end
+
   @doc """
   Sets the global Gettext locale for the current process.
 
@@ -760,7 +771,11 @@ defmodule Gettext do
   """
   @doc section: :locale
   @spec put_locale(backend, locale) :: locale | nil
-  def put_locale(backend, locale) when is_binary(locale), do: Process.put(backend, locale)
+  def put_locale(backend, locale) when is_binary(locale) do
+    language_fallback(backend)
+
+    Process.put(backend, locale)
+  end
 
   def put_locale(_backend, locale),
     do: raise(ArgumentError, "put_locale/2 only accepts binary locales, got: #{inspect(locale)}")


### PR DESCRIPTION
## Linear Ticket
https://linear.app/ovice/issue/ZERO-6329

## Overview

**put_locale/2** now instead of just changing the locale language it will pass  **language_fallback** function

**fallback_language** will check if the passed locale exists in the backlend allowed_locales if not it will fallback to the english otherwise it will work as the original **put_locale/2**

## Areas to focus on
